### PR TITLE
keyToggle and keyTap crashed with non-english input source

### DIFF
--- a/src/keycode.c
+++ b/src/keycode.c
@@ -134,7 +134,7 @@ MMKeyCode keyCodeForChar(const char c)
 
 CFStringRef createStringForKey(CGKeyCode keyCode)
 {
-	TISInputSourceRef currentKeyboard = TISCopyCurrentASCIICapableKeyboardInputSource();
+	TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardLayoutInputSource();
 	CFDataRef layoutData =
 		TISGetInputSourceProperty(currentKeyboard,
 		                          kTISPropertyUnicodeKeyLayoutData);


### PR DESCRIPTION
Related #294